### PR TITLE
Fix Ctrl+S save, About version display, and file panel layout

### DIFF
--- a/src/components/SettingsSheet.tsx
+++ b/src/components/SettingsSheet.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { getVersion } from "@tauri-apps/api/app";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
@@ -98,6 +99,7 @@ export default function SettingsSheet({ open, onOpenChange }: SettingsSheetProps
   } = useSettingsStore();
 
   const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+  const [appVersion, setAppVersion] = useState<string>("");
   const [localDefaultClonePath, setLocalDefaultClonePath] = useState(defaultClonePath || "");
   const [installedAssistants, setInstalledAssistants] = useState<string[]>([]);
   const [installingCommands, setInstallingCommands] = useState<Set<string>>(new Set());
@@ -119,6 +121,11 @@ export default function SettingsSheet({ open, onOpenChange }: SettingsSheetProps
   const [assistantArgsState, setAssistantArgsState] = useState<Record<string, string>>(buildArgsState);
 
   const { isChecking: isCheckingUpdate, checkForUpdates, updateAvailable } = useUpdateStore();
+
+  // Fetch app version from Tauri
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => setAppVersion("unknown"));
+  }, []);
 
   // Update local state when store changes
   useEffect(() => {
@@ -855,7 +862,7 @@ export default function SettingsSheet({ open, onOpenChange }: SettingsSheetProps
                     <div className="space-y-4">
                       <div className="flex items-center justify-between py-2">
                         <p className="text-sm text-muted-foreground">Version</p>
-                        <p className="text-sm font-mono">0.1.1</p>
+                        <p className="text-sm font-mono">{appVersion || "..."}</p>
                       </div>
                       <div className="flex items-center justify-between py-2">
                         <p className="text-sm text-muted-foreground">Build</p>


### PR DESCRIPTION
## Summary
- **Fix Ctrl+S save behavior:** Ctrl+S (and save icon) now saves the file without closing it. Fixed stale closure issue where save was writing the original content instead of current edits by reading directly from the Monaco editor instance.
- **Fix About version display:** Replaced hardcoded "0.1.1" with dynamic version fetched from Tauri API, so it correctly shows the actual app version.
- **Fix file panel layout:** When no terminal/assistant widgets are open, the file editor panel now expands to full available width instead of staying at a fixed 400px.

## Test plan
- [ ] Open a file, make edits, press Ctrl+S — file should save without closing and retain edits
- [ ] Click the save icon — same behavior as Ctrl+S
- [ ] Open Settings → About — version should show current version (0.1.78)
- [ ] Close all terminal/assistant panels, open a file — editor should fill the available width